### PR TITLE
Potential fix for code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const bcrypt = require('bcrypt');
 const jwt = require('jsonwebtoken');
+const rateLimit = require('express-rate-limit');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
@@ -9,6 +10,13 @@ const JWT_SECRET = process.env.JWT_SECRET || 'your_fallback_secret';
 
 app.use(cors());
 app.use(express.json());
+
+// Rate limiter: max 100 requests per 15 minutes per IP
+const apiLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  message: { error: "Too many requests, please try again later." }
+});
 
 // Mock user DB (replace with real DB in production)
 const users = [
@@ -46,19 +54,19 @@ function authenticate(req, res, next) {
 }
 
 // Get current user's playlist
-app.get('/api/playlists', authenticate, (req, res) => {
+app.get('/api/playlists', apiLimiter, authenticate, (req, res) => {
   res.json(playlists[req.userId] || []);
 });
 
 // Add song to playlist
-app.post('/api/playlists', authenticate, (req, res) => {
+app.post('/api/playlists', apiLimiter, authenticate, (req, res) => {
   playlists[req.userId] = playlists[req.userId] || [];
   playlists[req.userId].push(req.body);
   res.status(201).json({ message: 'Song added' });
 });
 
 // Clear user's playlist
-app.delete('/api/playlists', authenticate, (req, res) => {
+app.delete('/api/playlists', apiLimiter, authenticate, (req, res) => {
   playlists[req.userId] = [];
   res.json({ message: 'Playlist cleared' });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/music/security/code-scanning/5](https://github.com/MOHAMMAD3230/music/security/code-scanning/5)

To mitigate this vulnerability, add a rate-limiting middleware to API routes that perform authorization using JWT verification. The best way is to use the well-known `express-rate-limit` package. The fix involves importing `express-rate-limit`, configuring an appropriate limit (e.g., 100 requests per 15 minutes, or stricter if desired), and applying it specifically to the authenticated `/api/playlists` routes (GET, POST, DELETE). You can define the limiter once and attach it to the relevant routes before the authenticate middleware.

**Steps:**
- Add `express-rate-limit` as an import at the top of `server.js`.
- Set up the rate limiter (`windowMs`, `max`, and perhaps a message).
- Attach the limiter as middleware for all three `/api/playlists` routes.
- No changes to the functionality of those endpoints otherwise.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
