### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-heroku.yml
+++ b/.github/workflows/deploy-heroku.yml
@@ -1,4 +1,6 @@
 name: Deploy Node.js Backend to Heroku
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/MOHAMMAD3230/music/security/code-scanning/2](https://github.com/MOHAMMAD3230/music/security/code-scanning/2)

To fix the problem, an explicit `permissions` block should be added to the workflow file. The minimal set of permissions necessary for a Heroku deploy (and steps as shown) is `contents: read`—steps only need read-access to fetch code, and do not require GitHub API write operations. This permissions block can be added at either the workflow root (applies to all jobs), or at the individual job level (only applies to that job). In this situation (single job), it's simplest and clearest to add it at the workflow root, immediately after the `name:` entry and before (or after) the `on:` block.

No further code changes or imports are needed, just a new block in the YAML workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
